### PR TITLE
Add spawn_items functionality for admin gear spawning with NFT minting

### DIFF
--- a/src/models/core.cairo
+++ b/src/models/core.cairo
@@ -16,4 +16,14 @@ pub struct Contract {
     pub id: felt252,
     pub admin: ContractAddress,
     pub erc1155: ContractAddress,
+    pub warehouse: ContractAddress,
+}
+
+
+#[dojo::model]
+#[derive(Drop, Copy, Serde, Default)]
+pub struct GearCounter {
+    #[key]
+    pub id: u128, // gear type
+    pub counter: u128,
 }

--- a/src/models/gear.cairo
+++ b/src/models/gear.cairo
@@ -62,6 +62,33 @@ pub struct GearProperties {
     // asset: Gear,
 }
 
+pub impl GearTypeU128 of Into<GearType, u128> {
+    fn into(self: GearType) -> u128 {
+        match self {
+            GearType::Weapon => 0x1,
+            GearType::BluntWeapon => 0x101,
+            GearType::Sword => 0x102,
+            GearType::Bow => 0x103,
+            GearType::Firearm => 0x104,
+            GearType::Polearm => 0x105,
+            GearType::HeavyFirearms => 0x106,
+            GearType::Explosives => 0x107,
+            GearType::Helmet => 0x2000,
+            GearType::ChestArmor => 0x2001,
+            GearType::LegArmor => 0x2002,
+            GearType::Boots => 0x2003,
+            GearType::Gloves => 0x2004,
+            GearType::Shield => 0x2005,
+            GearType::Vehicle => 0x30000,
+            GearType::Pet => 0x800000,
+            GearType::Drone => 0x800001,
+            GearType::None => 0x0,
+        }
+    }
+}
+
+
+
 // for now, all items would implement this trait
 // move this trait and it's impl to `helpers/gear.cairo`
 

--- a/src/models/gear.cairo
+++ b/src/models/gear.cairo
@@ -87,7 +87,13 @@ pub impl GearTypeU128 of Into<GearType, u128> {
     }
 }
 
-
+#[derive(Drop, Copy, Serde)]
+#[dojo::event]
+pub struct GearSpawned {
+    #[key]
+    pub admin: ContractAddress,
+    pub item_types: Array<u256>,
+}
 
 // for now, all items would implement this trait
 // move this trait and it's impl to `helpers/gear.cairo`


### PR DESCRIPTION
## Description
This PR implements the `spawn_items` function in the CoreActions contract, enabling admins to spawn gear items into the system.

### Key Features:
- **Admin-only access**: Only contract admins can call this function
- **Batch spawning**: Supports spawning multiple item types in a single transaction
- **ERC1155 integration**: Mints items using the ERC1155 contract
- **State management**: Updates gear spawn status and increments counters
- **Event emission**: Emits `GearSpawned` event for tracking

### Implementation Details:
- Validates caller is admin before proceeding
- Iterates through provided item types array
- Checks gear hasn't been spawned previously
- Increments gear counter for unique item IDs
- Mints items to warehouse address via ERC1155
- Updates gear spawn status to prevent duplicate spawning
- Emits event with admin address and item types

## Related Issue
Closes #91 