### PR TITLE
Adding position model and system functionalities

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -6,6 +6,7 @@ pub mod systems {
     pub mod pet;
     pub mod tournament;
     pub mod session;
+    pub mod position;
 }
 
 pub mod erc1155 {
@@ -17,6 +18,7 @@ pub mod models {
     pub mod core;
     pub mod gear;
     pub mod armour;
+    pub mod position;
     pub mod marketplace;
     pub mod weapon_stats;
     pub mod armor_stats;

--- a/src/models/position.cairo
+++ b/src/models/position.cairo
@@ -10,7 +10,7 @@ pub struct Position {
 }
 
 #[dojo::model]
-#[derive(Drop, Copy, Serde)]
+#[derive(Copy, Drop, Serde)]
 pub struct PositionHistory {
     #[key]
     pub player_id: felt252,

--- a/src/models/position.cairo
+++ b/src/models/position.cairo
@@ -16,6 +16,8 @@ pub struct PositionHistory {
     pub player_id: felt252,
     #[key]
     pub sequence: u64,
+    #[key]
+    pub subsequence: u32,
     pub x: u32,
     pub y: u32,
     pub z: u32,

--- a/src/models/position.cairo
+++ b/src/models/position.cairo
@@ -15,7 +15,7 @@ pub struct PositionHistory {
     #[key]
     pub player_id: felt252,
     #[key]
-    pub sequence: u32,
+    pub sequence: u64,
     pub x: u32,
     pub y: u32,
     pub z: u32,

--- a/src/models/position.cairo
+++ b/src/models/position.cairo
@@ -25,7 +25,7 @@ pub struct PositionHistory {
     pub movement_type: MovementType,
 }
 
-#[derive(Copy, Drop, Serde, PartialEq)]
+#[derive(Copy, Drop, Serde, PartialEq, Introspect)]
 pub enum MovementType {
     Walk,
     Run,

--- a/src/models/position.cairo
+++ b/src/models/position.cairo
@@ -1,0 +1,58 @@
+#[dojo::model]
+#[derive(Drop, Copy, Serde, Default)]
+pub struct Position {
+    #[key]
+    pub player_id: felt252,
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub last_updated: u64,
+}
+
+#[dojo::model]
+#[derive(Drop, Copy, Serde)]
+pub struct PositionHistory {
+    #[key]
+    pub player_id: felt252,
+    #[key]
+    pub sequence: u32,
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub timestamp: u64,
+    pub movement_type: MovementType,
+}
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub enum MovementType {
+    Walk,
+    Run,
+    Teleport,
+    Respawn,
+    Forced,
+}
+
+#[derive(Drop, Copy, Serde)]
+#[dojo::event]
+pub struct PlayerMoved {
+    #[key]
+    pub player_id: felt252,
+    pub from_x: u32,
+    pub from_y: u32,
+    pub from_z: u32,
+    pub to_x: u32,
+    pub to_y: u32,
+    pub to_z: u32,
+    pub movement_type: MovementType,
+    pub timestamp: u64,
+}
+
+#[derive(Drop, Copy, Serde)]
+#[dojo::event]
+pub struct PlayersInProximity {
+    #[key]
+    pub player1: felt252,
+    #[key]
+    pub player2: felt252,
+    pub distance: u32,
+}

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -16,7 +16,7 @@ pub trait IPosition<TContractState> {
     ) -> Array<Position>;
 
     fn validate_movement(
-        self: @TContractState, player_id: felt252, from: Position, to: Position,
+        self: @TContractState, player_id: felt252, from: Position, to: Position, movement_type: MovementType,
     ) -> bool;
 
     fn check_collision(self: @TContractState, x: u32, y: u32, z: u32) -> bool;
@@ -129,7 +129,7 @@ pub mod PositionActions {
         }
 
         fn validate_movement(
-            self: @ContractState, player_id: felt252, from: Position, to: Position,
+            self: @ContractState, player_id: felt252, from: Position, to: Position, movement_type: MovementType,
         ) -> bool {
             if !(to.x >= WORLD_MIN_X && to.x <= WORLD_MAX_X) {
                 return false;

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -1,0 +1,255 @@
+use crate::models::position::{Position, PositionHistory, MovementType};
+
+#[starknet::interface]
+pub trait IPosition<TContractState> {
+    fn move_player(
+        ref self: TContractState, player_id: felt252, new_x: u32, new_y: u32, new_z: u32,
+    );
+
+    fn get_player_position(self: @TContractState, player_id: felt252) -> Position;
+
+    fn get_players_in_area(
+        self: @TContractState, center_x: u32, center_y: u32, center_z: u32, radius: u32,
+    ) -> Array<Position>;
+
+    fn validate_movement(
+        self: @TContractState, player_id: felt252, from: Position, to: Position,
+    ) -> bool;
+
+    fn check_collision(self: @TContractState, x: u32, y: u32, z: u32) -> bool;
+
+    fn calculate_movement_distance(self: @TContractState, from: Position, to: Position) -> u32;
+
+    fn add_position_history(
+        ref self: TContractState,
+        player_id: felt252,
+        position: Position,
+        movement_type: MovementType,
+    );
+
+    fn get_position_history(
+        self: @TContractState, player_id: felt252, limit: u32,
+    ) -> Array<PositionHistory>;
+
+    fn cleanup_old_history(ref self: TContractState, player_id: felt252, keep_last: u32);
+}
+
+#[dojo::contract]
+pub mod PositionActions {
+    use starknet::get_block_timestamp;
+    use crate::models::position::{Position, PositionHistory, MovementType, PlayerMoved};
+    use super::IPosition;
+    use dojo::model::ModelStorage;
+    use dojo::event::EventStorage;
+    use core::array::ArrayTrait;
+
+    // Movement constraints
+    const MAX_MOVEMENT_DISTANCE: u32 = 100;
+    const WORLD_MIN_X: u32 = 0;
+    const WORLD_MAX_X: u32 = 10000;
+    const WORLD_MIN_Y: u32 = 0;
+    const WORLD_MAX_Y: u32 = 10000;
+    const WORLD_MIN_Z: u32 = 0;
+    const WORLD_MAX_Z: u32 = 1000;
+
+    // History management
+    const MAX_HISTORY_ENTRIES: u32 = 1000;
+    const HISTORY_CLEANUP_THRESHOLD: u32 = 1200;
+
+    #[abi(embed_v0)]
+    impl PositionActionsImpl of IPosition<ContractState> {
+        fn move_player(
+            ref self: ContractState, player_id: felt252, new_x: u32, new_y: u32, new_z: u32,
+        ) {
+            let mut world = self.world_default();
+
+            // Read current position (default if none)
+            let mut current: Position = world.read_model(player_id);
+
+            let from_x = current.x;
+            let from_y = current.y;
+            let from_z = current.z;
+
+            // Bounds checks
+            assert(new_x >= WORLD_MIN_X && new_x <= WORLD_MAX_X, 'INVALID_COORDINATES');
+            assert(new_y >= WORLD_MIN_Y && new_y <= WORLD_MAX_Y, 'INVALID_COORDINATES');
+            assert(new_z >= WORLD_MIN_Z && new_z <= WORLD_MAX_Z, 'INVALID_COORDINATES');
+
+            // Distance check (Manhattan)
+            let from = current;
+            let to = Position {
+                player_id, x: new_x, y: new_y, z: new_z, last_updated: from.last_updated,
+            };
+            let distance = self.calculate_movement_distance(from, to);
+            assert(distance <= MAX_MOVEMENT_DISTANCE, 'MOVEMENT_TOO_LARGE');
+
+            // Collision check (placeholder)
+            assert(!self.check_collision(new_x, new_y, new_z), 'COLLISION_DETECTED');
+
+            // Write new position
+            let ts = get_block_timestamp();
+            let updated = Position { player_id, x: new_x, y: new_y, z: new_z, last_updated: ts };
+            world.write_model(@updated);
+
+            // Record history and emit event
+            self.add_position_history(player_id, updated, MovementType::Walk);
+            let moved = PlayerMoved {
+                player_id,
+                from_x,
+                from_y,
+                from_z,
+                to_x: new_x,
+                to_y: new_y,
+                to_z: new_z,
+                movement_type: MovementType::Walk,
+                timestamp: ts,
+            };
+            world.emit_event(@moved);
+        }
+
+        fn get_player_position(self: @ContractState, player_id: felt252) -> Position {
+            let world = self.world_default();
+            let pos: Position = world.read_model(player_id);
+            assert(pos.last_updated != 0, 'PLAYER_NOT_FOUND');
+            pos
+        }
+
+        fn get_players_in_area(
+            self: @ContractState, center_x: u32, center_y: u32, center_z: u32, radius: u32,
+        ) -> Array<Position> {
+            // Placeholder: requires indexing
+            array![]
+        }
+
+        fn validate_movement(
+            self: @ContractState, player_id: felt252, from: Position, to: Position,
+        ) -> bool {
+            if !(to.x >= WORLD_MIN_X && to.x <= WORLD_MAX_X) {
+                return false;
+            }
+            if !(to.y >= WORLD_MIN_Y && to.y <= WORLD_MAX_Y) {
+                return false;
+            }
+            if !(to.z >= WORLD_MIN_Z && to.z <= WORLD_MAX_Z) {
+                return false;
+            }
+            let distance = self.calculate_movement_distance(from, to);
+            if distance > MAX_MOVEMENT_DISTANCE {
+                return false;
+            }
+            if self.check_collision(to.x, to.y, to.z) {
+                return false;
+            }
+            true
+        }
+
+        fn check_collision(self: @ContractState, x: u32, y: u32, z: u32) -> bool {
+            // No obstacles model yet
+            false
+        }
+
+        fn calculate_movement_distance(self: @ContractState, from: Position, to: Position) -> u32 {
+            let dx = if to.x >= from.x {
+                to.x - from.x
+            } else {
+                from.x - to.x
+            };
+            let dy = if to.y >= from.y {
+                to.y - from.y
+            } else {
+                from.y - to.y
+            };
+            let dz = if to.z >= from.z {
+                to.z - from.z
+            } else {
+                from.z - to.z
+            };
+            dx + dy + dz
+        }
+
+        fn add_position_history(
+            ref self: ContractState,
+            player_id: felt252,
+            position: Position,
+            movement_type: MovementType,
+        ) {
+            let mut world = self.world_default();
+            let ts = get_block_timestamp();
+            // Use timestamp (truncated) as a monotonic sequence surrogate
+            let seq: u32 = ts.into();
+            let history = PositionHistory {
+                player_id,
+                sequence: seq,
+                x: position.x,
+                y: position.y,
+                z: position.z,
+                timestamp: ts,
+                movement_type,
+            };
+            world.write_model(@history);
+        }
+
+        fn get_position_history(
+            self: @ContractState, player_id: felt252, limit: u32,
+        ) -> Array<PositionHistory> {
+            let world = self.world_default();
+            let now = get_block_timestamp();
+            let mut seq: u32 = now.into();
+            let mut collected: u32 = 0;
+            let mut result: Array<PositionHistory> = array![];
+            loop {
+                if collected >= limit {
+                    break;
+                }
+                // Bound search window to 1h worth of seconds to limit gas
+                if (now - seq.into()) > 3600_u64 {
+                    break;
+                }
+                let entry: PositionHistory = world.read_model((player_id, seq));
+                if entry.timestamp != 0 {
+                    result.append(entry);
+                    collected += 1;
+                }
+                if seq == 0 {
+                    break;
+                }
+                seq -= 1;
+            };
+            result
+        }
+
+        fn cleanup_old_history(ref self: ContractState, player_id: felt252, keep_last: u32) {
+            let mut world = self.world_default();
+            let now = get_block_timestamp();
+            let mut seq: u32 = now.into();
+            let mut kept: u32 = 0;
+            let mut scanned: u32 = 0;
+            loop {
+                if scanned >= HISTORY_CLEANUP_THRESHOLD {
+                    break;
+                }
+                let entry: PositionHistory = world.read_model((player_id, seq));
+                if entry.timestamp != 0 {
+                    if kept < keep_last {
+                        kept += 1;
+                    } else {
+                        // Best-effort deletion; depends on Dojo ModelStorage delete support
+                        world.delete_model((player_id, seq));
+                    }
+                }
+                scanned += 1;
+                if seq == 0 {
+                    break;
+                }
+                seq -= 1;
+            };
+        }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn world_default(self: @ContractState) -> dojo::world::WorldStorage {
+            self.world(@"coa")
+        }
+    }
+}

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -77,21 +77,13 @@ pub mod PositionActions {
             let from_y = current.y;
             let from_z = current.z;
 
-            // Bounds checks
-            assert(new_x >= WORLD_MIN_X && new_x <= WORLD_MAX_X, 'INVALID_COORDINATES');
-            assert(new_y >= WORLD_MIN_Y && new_y <= WORLD_MAX_Y, 'INVALID_COORDINATES');
-            assert(new_z >= WORLD_MIN_Z && new_z <= WORLD_MAX_Z, 'INVALID_COORDINATES');
-
-            // Distance check (Manhattan)
             let from = current;
             let to = Position {
                 player_id, x: new_x, y: new_y, z: new_z, last_updated: from.last_updated,
             };
-            let distance = self.calculate_movement_distance(from, to);
-            assert(distance <= MAX_MOVEMENT_DISTANCE, 'MOVEMENT_TOO_LARGE');
 
-            // Collision check (placeholder)
-            assert(!self.check_collision(new_x, new_y, new_z), 'COLLISION_DETECTED');
+            // Centralized validation (see validate_movement)
+            assert(self.validate_movement(player_id, from, to, movement_type), 'INVALID_MOVE');
 
             // Write new position
             let ts = get_block_timestamp();

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -3,7 +3,10 @@ use crate::models::position::{Position, PositionHistory, MovementType};
 #[starknet::interface]
 pub trait IPosition<TContractState> {
     fn move_player(
-        ref self: TContractState, player_id: felt252, new_x: u32, new_y: u32, new_z: u32,
+        ref self: TContractState,
+        player_id: felt252,
+        movement_type: MovementType,
+        new_x: u32, new_y: u32, new_z: u32,
     );
 
     fn get_player_position(self: @TContractState, player_id: felt252) -> Position;
@@ -59,7 +62,10 @@ pub mod PositionActions {
     #[abi(embed_v0)]
     impl PositionActionsImpl of IPosition<ContractState> {
         fn move_player(
-            ref self: ContractState, player_id: felt252, new_x: u32, new_y: u32, new_z: u32,
+            ref self: ContractState, 
+            player_id: felt252, 
+            movement_type: MovementType, 
+            new_x: u32, new_y: u32, new_z: u32,
         ) {
             let mut world = self.world_default();
 

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -205,7 +205,7 @@ pub mod PositionActions {
                     break;
                 }
                 seq += 1_u64;
-            }
+            };
             let history = PositionHistory {
                 player_id,
                 sequence: seq,

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -42,7 +42,6 @@ pub mod PositionActions {
     use dojo::model::ModelStorage;
     use dojo::event::EventStorage;
     use core::array::ArrayTrait;
-    use core::traits::TryInto;
 
     // Movement constraints
     const MAX_MOVEMENT_DISTANCE: u32 = 100;
@@ -177,8 +176,8 @@ pub mod PositionActions {
         ) {
             let mut world = self.world_default();
             let ts = get_block_timestamp();
-            // Use timestamp (truncated) as a monotonic sequence surrogate
-            let seq: u32 = ts.try_into().unwrap_or(0);
+            // Use timestamp as a monotonic sequence surrogate
+            let seq: u64 = ts;
             let history = PositionHistory {
                 player_id,
                 sequence: seq,
@@ -196,7 +195,7 @@ pub mod PositionActions {
         ) -> Array<PositionHistory> {
             let world = self.world_default();
             let now = get_block_timestamp();
-            let mut seq: u32 = now.try_into().unwrap_or(0);
+            let mut seq: u64 = now;
             let mut collected: u32 = 0;
             let mut result: Array<PositionHistory> = array![];
             loop {
@@ -204,8 +203,7 @@ pub mod PositionActions {
                     break;
                 }
                 // Bound search window to 1h worth of seconds to limit gas
-                let seq64: u64 = seq.try_into().unwrap_or(0);
-                if (now - seq64) > 3600_u64 {
+                if (now - seq) > 3600_u64 {
                     break;
                 }
                 let entry: PositionHistory = world.read_model((player_id, seq));
@@ -224,7 +222,7 @@ pub mod PositionActions {
         fn cleanup_old_history(ref self: ContractState, player_id: felt252, keep_last: u32) {
             let mut world = self.world_default();
             let now = get_block_timestamp();
-            let mut seq: u32 = now.try_into().unwrap_or(0);
+            let mut seq: u64 = now;
             let mut kept: u32 = 0;
             let mut scanned: u32 = 0;
             loop {

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -181,6 +181,7 @@ pub mod PositionActions {
             let history = PositionHistory {
                 player_id,
                 sequence: seq,
+                subsequence: 0,
                 x: position.x,
                 y: position.y,
                 z: position.z,

--- a/src/systems/position.cairo
+++ b/src/systems/position.cairo
@@ -27,6 +27,7 @@ pub trait IPosition<TContractState> {
         ref self: TContractState,
         player_id: felt252,
         position: Position,
+        timestamp: u64,
         movement_type: MovementType,
     );
 
@@ -98,7 +99,7 @@ pub mod PositionActions {
             world.write_model(@updated);
 
             // Record history and emit event
-            self.add_position_history(player_id, updated, MovementType::Walk);
+            self.add_position_history(player_id, updated, ts, movement_type);
             let moved = PlayerMoved {
                 player_id,
                 from_x,
@@ -107,7 +108,7 @@ pub mod PositionActions {
                 to_x: new_x,
                 to_y: new_y,
                 to_z: new_z,
-                movement_type: MovementType::Walk,
+                movement_type,
                 timestamp: ts,
             };
             world.emit_event(@moved);
@@ -178,12 +179,12 @@ pub mod PositionActions {
             ref self: ContractState,
             player_id: felt252,
             position: Position,
+            timestamp: u64,
             movement_type: MovementType,
         ) {
             let mut world = self.world_default();
-            let ts = get_block_timestamp();
             // Use timestamp as a monotonic sequence surrogate
-            let seq: u64 = ts;
+            let seq: u64 = timestamp;
             let history = PositionHistory {
                 player_id,
                 sequence: seq,
@@ -191,7 +192,7 @@ pub mod PositionActions {
                 x: position.x,
                 y: position.y,
                 z: position.z,
-                timestamp: ts,
+                timestamp,
                 movement_type,
             };
             world.write_model(@history);


### PR DESCRIPTION
### PR: Position System (Models + Systems)

- Implemented 3D position tracking with on-chain storage and events.
  - src/models/position.cairo:
    - Added `Position` and `PositionHistory` Dojo models
    - Added `MovementType` enum
    - Added `PlayerMoved` and `PlayersInProximity` events

- Added position system with validation and history.
  - src/systems/position.cairo:
    - `move_player`: bounds + max Manhattan distance, collision check (stub=false), writes `Position`, appends `PositionHistory`, emits `PlayerMoved`
    - `get_player_position`: returns stored `Position` with existence check
    - `validate_movement`: shared checks for bounds, distance, collision
    - `calculate_movement_distance`: Manhattan distance
    - `check_collision`: obstacle-only (returns false until obstacle model exists)
    - `get_players_in_area`: placeholder (requires indexing)
    - `add_position_history`: uses `block_timestamp` as sequence surrogate
    - `get_position_history`: bounded reverse scan by sequence; respects `limit`
    - `cleanup_old_history`: keeps last N via bounded reverse scan (no delete without Dojo API)
    - `world_default` helper

- Constants: `MAX_MOVEMENT_DISTANCE=100`, world bounds for X/Y/Z, history thresholds

Notes
- Multiple players can share a position; collision targets obstacles only
- History/query/cleanup are best-effort until indexing is added

Reference: [Issue #104](https://github.com/SunsetLabs-Game/COA-Contracts/issues/104)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Position management: players can move with world bounds, max-step validation, and multiple movement types (Walk, Run, Teleport, Respawn, Forced).
  * Retrieve current player position.
  * Per-player position history with timestamps, sequencing, and automatic cleanup.
  * Movement events emitted when players move.
  * Proximity events defined for nearby players.
  * Area-based player queries scaffolded (placeholder until indexing available).
  * Basic collision checks present but currently non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->